### PR TITLE
reduce possible MongoDB connection count

### DIFF
--- a/src/allzpark/backend_avalon.py
+++ b/src/allzpark/backend_avalon.py
@@ -3,6 +3,7 @@ import os
 import time
 import logging
 import getpass
+import functools
 from itertools import groupby
 from dataclasses import dataclass
 from functools import singledispatch
@@ -756,6 +757,11 @@ def iter_avalon_tasks(avalon_asset):
         )
 
 
+@functools.lru_cache(maxsize=None)
+def _get_connection(uri, timeout):
+    return MongoClient(uri, serverSelectionTimeoutMS=timeout)
+
+
 class AvalonMongo(object):
     """Avalon MongoDB connector
     """
@@ -767,7 +773,7 @@ class AvalonMongo(object):
             connection. Optional.
         :type entrance: Entrance or None
         """
-        conn = MongoClient(uri, serverSelectionTimeoutMS=timeout)
+        conn = _get_connection(uri, timeout)
 
         self.uri = uri
         self.conn = conn


### PR DESCRIPTION
### Problem

MongoDB connection is being made for each tool launching history (breadcrumb), this *might be (or one of)* the cause of connection overhead in the facility.

https://github.com/MoonShineVFX/park/blob/089eb9317053f4447360c0185f79ba2a747badb7/src/allzpark/backend_avalon.py#L571-L576

### Fix

Use `lru_cache` to reuse connections. (only one connection per `(uri, timeout)`)
